### PR TITLE
Bug Fix #21

### DIFF
--- a/src/components/ApiMenu/ApiMenu.tsx
+++ b/src/components/ApiMenu/ApiMenu.tsx
@@ -42,9 +42,10 @@ const ApiMenu = ({
 
   useEffect(() => {
     if (apiKey) {
-      _setApiFree(false);
-      _setApiKey(apiKey);
-    }
+    setApiFree(false);
+    _setApiFree(false);
+    _setApiKey(apiKey);
+  }
   }, []);
 
   return isModalOpen ? (

--- a/src/components/ApiMenu/ApiMenu.tsx
+++ b/src/components/ApiMenu/ApiMenu.tsx
@@ -16,17 +16,20 @@ const ApiMenu = ({
   const apiFree = useStore((state) => state.apiFree);
   const setApiFree = useStore((state) => state.setApiFree);
 
+  const [selectedApiFree, setSelectedApiFree] = useState<boolean>(apiFree);
   const [_apiKey, _setApiKey] = useState<string>(apiKey || '');
   const [error, setError] = useState<boolean>(false);
 
   const handleSave = async () => {
-    if (apiFree === true) {
+    if (selectedApiFree === true) {
+      setApiFree(true);
       setIsModalOpen(false);
     } else {
       const valid = await validateApiKey(_apiKey);
 
       if (valid) {
         setApiKey(_apiKey);
+        setApiFree(false);
         setError(false);
         setIsModalOpen(false);
       } else {
@@ -40,7 +43,7 @@ const ApiMenu = ({
 
   useEffect(() => {
     if (apiKey) {
-      setApiFree(false);
+      setSelectedApiFree(false);
       _setApiKey(apiKey);
     }
   }, []);
@@ -55,9 +58,9 @@ const ApiMenu = ({
         <div className='flex items-center mb-2'>
           <input
             type='radio'
-            checked={apiFree === true}
+            checked={selectedApiFree === true}
             className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
-            onChange={() => setApiFree(true)}
+            onChange={() => setSelectedApiFree(true)}
           />
           <label className='ml-2 text-sm font-medium text-gray-900 dark:text-gray-300'>
             Use free API from{' '}
@@ -74,16 +77,16 @@ const ApiMenu = ({
         <div className='flex items-center'>
           <input
             type='radio'
-            checked={apiFree === false}
+            checked={selectedApiFree === false}
             className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
-            onChange={() => setApiFree(false)}
+            onChange={() => setSelectedApiFree(false)}
           />
           <label className='ml-2 text-sm font-medium text-gray-900 dark:text-gray-300'>
             Use your own API key
           </label>
         </div>
 
-        {apiFree === false && (
+        {selectedApiFree === false && (
           <>
             <div className='flex gap-2 items-center justify-center mt-2'>
               <div className='min-w-fit text-gray-900 dark:text-gray-300 text-sm'>
@@ -91,7 +94,7 @@ const ApiMenu = ({
               </div>
               <input
                 type='text'
-                className='text-gray-800 dark:text-white p-3 text-sm border-none bg-gray-200 dark:bg-gray-600 rounded-md p-0 m-0 w-full mr-0 h-8 focus:outline-none'
+                className='text-gray-800 dark:text-white p-3 text-sm border-none bg-gray-200 dark:bg-gray-600 rounded-md m-0 w-full mr-0 h-8 focus:outline-none'
                 value={_apiKey}
                 onChange={(e) => {
                   _setApiKey(e.target.value);
@@ -100,7 +103,8 @@ const ApiMenu = ({
             </div>
             {error && (
               <div className='bg-red-600/50 p-2 rounded-sm mt-3 text-gray-900 dark:text-gray-300 text-sm'>
-                Error: Invalid API key or network blocked. Please check your API key and network settings for OpenAI API.
+                Error: Invalid API key or network blocked. Please check your API
+                key and network settings for OpenAI API.
               </div>
             )}
           </>

--- a/src/components/ApiMenu/ApiMenu.tsx
+++ b/src/components/ApiMenu/ApiMenu.tsx
@@ -16,17 +16,16 @@ const ApiMenu = ({
   const apiFree = useStore((state) => state.apiFree);
   const setApiFree = useStore((state) => state.setApiFree);
 
-  const [selectedApiFree, setSelectedApiFree] = useState<boolean>(apiFree);
+  const [_apiFree, _setApiFree] = useState<boolean>(apiFree);
   const [_apiKey, _setApiKey] = useState<string>(apiKey || '');
   const [error, setError] = useState<boolean>(false);
 
   const handleSave = async () => {
-    if (selectedApiFree === true) {
+    if (_apiFree === true) {
       setApiFree(true);
       setIsModalOpen(false);
     } else {
       const valid = await validateApiKey(_apiKey);
-
       if (valid) {
         setApiKey(_apiKey);
         setApiFree(false);
@@ -43,7 +42,7 @@ const ApiMenu = ({
 
   useEffect(() => {
     if (apiKey) {
-      setSelectedApiFree(false);
+      _setApiFree(false);
       _setApiKey(apiKey);
     }
   }, []);
@@ -58,9 +57,9 @@ const ApiMenu = ({
         <div className='flex items-center mb-2'>
           <input
             type='radio'
-            checked={selectedApiFree === true}
+            checked={_apiFree === true}
             className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
-            onChange={() => setSelectedApiFree(true)}
+            onChange={() => _setApiFree(true)}
           />
           <label className='ml-2 text-sm font-medium text-gray-900 dark:text-gray-300'>
             Use free API from{' '}
@@ -73,20 +72,19 @@ const ApiMenu = ({
             </a>
           </label>
         </div>
-
         <div className='flex items-center'>
           <input
             type='radio'
-            checked={selectedApiFree === false}
+            checked={_apiFree === false}
             className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
-            onChange={() => setSelectedApiFree(false)}
+            onChange={() => _setApiFree(false)}
           />
           <label className='ml-2 text-sm font-medium text-gray-900 dark:text-gray-300'>
             Use your own API key
           </label>
         </div>
 
-        {selectedApiFree === false && (
+        {_apiFree === false && (
           <>
             <div className='flex gap-2 items-center justify-center mt-2'>
               <div className='min-w-fit text-gray-900 dark:text-gray-300 text-sm'>


### PR DESCRIPTION
The issue with the code lies in the handleSave function of the ApiMenu component, specifically in the if (apiFree === true) condition. When apiFree is true, the handleSave function closes the modal, regardless of whether the user selected "Use your own API key" or "Use free API provided by Ayaka" before clicking the "Cancel" button. This means that the configuration is not being reverted back to "Free" even though the user canceled the selection of their own API key.

To fix the bug, we will need to update the handleSave function to properly handle the "Cancel" button. One approach is to introduce a new state variable called selectedApiFree that tracks the user's selected API option. We can set it to the initial value of apiFree, and update it whenever the user toggles the radio buttons. Then, in the handleSave function, we can use selectedApiFree instead of apiFree to determine whether to close the modal or update the API key. With this approach, clicking "Cancel" will revert the configuration to the previously selected option.

Note that in the updated code, setSelectedApiFree(true) corresponds to selecting "Use free API provided by Ayaka", while setSelectedApiFree(false) corresponds to selecting "Use your own API key".

Reference: #21 