### PR TITLE
Remove padding at the end

### DIFF
--- a/src/components/Chat/ChatContent/ChatContent.tsx
+++ b/src/components/Chat/ChatContent/ChatContent.tsx
@@ -74,8 +74,6 @@ const ChatContent = () => {
               </div>
             </div>
           )}
-
-          <div className='w-full h-36'></div>
         </div>
       </ScrollToBottom>
     </div>


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/68557794/223125656-48af4e3d-33ab-4c65-b537-62305453a77b.png)

There is redundant padding at the bottom. This PR removes it.

However, this may cause the "Stop Generating" button to overlap above the "Save & Submit" button.

![](https://user-images.githubusercontent.com/68557794/223125978-706828da-6d1e-41cf-b4ab-c6ddc5f85bb5.png)

I think we can make further changes by hiding the "Save & Submit" button during generation.