### PR TITLE
Add fixes for deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "rehype-katex": "^6.0.2",
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
-    "zustand": "^4.3.5"
+    "zustand": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.9",

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,4 +1,4 @@
-import create, { SetState, GetState } from 'zustand';
+import { StoreApi, create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { ChatSlice, createChatSlice } from './chat-slice';
 import { InputSlice, createInputSlice } from './input-slice';
@@ -8,8 +8,8 @@ import { ConfigSlice, createConfigSlice } from './config-slice';
 export type StoreState = ChatSlice & InputSlice & AuthSlice & ConfigSlice;
 
 export type StoreSlice<T> = (
-  set: SetState<StoreState>,
-  get: GetState<StoreState>
+  set: StoreApi<StoreState>['setState'],
+  get: StoreApi<StoreState>['getState']
 ) => T;
 
 const useStore = create<StoreState>()(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2101,10 +2101,10 @@ yaml@^1.10.0, yaml@^1.10.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-zustand@^4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.5.tgz#011d2997534f8a187ea7b1d75db56df31f58453d"
-  integrity sha512-2iPUzfwx+g3f0PagOMz2vDO9mZzEp2puFpNe7vrAymVPOEIEUjCPkC4/zy84eAscxIWmTU4j9g6upXYkJdzEFQ==
+zustand@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.6.tgz#ce7804eb75361af0461a2d0536b65461ec5de86f"
+  integrity sha512-6J5zDxjxLE+yukC2XZWf/IyWVKnXT9b9HUv09VJ/bwGCpKNcaTqp7Ws28Xr8jnbvnZcdRaidztAPsXFBIqufiw==
   dependencies:
     use-sync-external-store "1.2.0"
 


### PR DESCRIPTION
This pull request updates the application to fix the following deprecation warnings:

- 'GetState' is deprecated. You might be looking for StateCreator, if not then use StoreApi<T>['getState'] instead of GetState<T>.
- 'SetState' is deprecated. You might be looking for StateCreator, if not then use StoreApi<T>['setState'] instead of SetState<T>.
- 'create' is deprecated. Use import { create } from 'zustand' instead.

The changes include updating the imports and types in store.ts and modifying the parameters of the store slice functions to use StoreApi instead of GetState and SetState.

I have tested the changes locally to make sure that they do not introduce any regressions.
