### PR TITLE
Temporarily change the free API endpoint URL

### DIFF
--- a/src/components/ApiMenu/ApiMenu.tsx
+++ b/src/components/ApiMenu/ApiMenu.tsx
@@ -79,7 +79,7 @@ const ApiMenu = ({
               >
                 Ayaka
               </a>
-              : https://chatgpt-api.shn.hk/v1/ or enter your own API endpoint
+              : https://chatgpt-api-huuz62kfra-as.a.run.app/v1/ or enter your own API endpoint
             </div>
             <div className='flex gap-2 items-center justify-center'>
               <div className='min-w-fit text-gray-900 dark:text-gray-300 text-sm'>
@@ -89,7 +89,7 @@ const ApiMenu = ({
                 type='text'
                 className='text-gray-800 dark:text-white p-3 text-sm border-none bg-gray-200 dark:bg-gray-600 rounded-md m-0 w-full mr-0 h-8 focus:outline-none'
                 value={_apiFreeEndpoint}
-                placeholder='https://chatgpt-api.shn.hk/v1/'
+                placeholder='https://chatgpt-api-huuz62kfra-as.a.run.app/v1/'
                 onChange={(e) => {
                   _setApiFreeEndpoint(e.target.value);
                 }}

--- a/src/store/auth-slice.ts
+++ b/src/store/auth-slice.ts
@@ -11,7 +11,7 @@ export interface AuthSlice {
 
 export const createAuthSlice: StoreSlice<AuthSlice> = (set, get) => ({
   apiFree: true,
-  apiFreeEndpoint: 'https://chatgpt-api.shn.hk/v1/',
+  apiFreeEndpoint: 'https://chatgpt-api-huuz62kfra-as.a.run.app/v1/',
   setApiKey: (apiKey: string) => {
     set((prev: AuthSlice) => ({
       ...prev,


### PR DESCRIPTION
I am currently transitioning from Cloudflare to Google Cloud Run, and the process of updating the domain name DNS records will take some time. During this period, the domain name for the API must be changed to the default domain name provided by Google Cloud Run. Once the DNS records have been updated, the domain name can be changed back to its original setting. See https://github.com/ayaka14732/ChatGPTAPIFree/pull/13.